### PR TITLE
Fix chat message imports/types

### DIFF
--- a/client/src/components/ChatMessages.tsx
+++ b/client/src/components/ChatMessages.tsx
@@ -1,13 +1,13 @@
 import React, { useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { ChatMessage } from "@/types";
+import { Message } from "@/types";
 import { format } from "date-fns";
 import { User, Bot } from "lucide-react";
 import TypingIndicator from "./TypingIndicator";
 import { cn } from "@/lib/utils";
 
 interface ChatMessagesProps {
-  messages: ChatMessage[];
+  messages: Message[];
   isTyping: boolean;
 }
 

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
-import { Header } from "@/components/Header";
-import { ChatMessages } from "@/components/ChatMessages";
-import { ChatInput } from "@/components/ChatInput";
+import ChatHeader from "@/components/ChatHeader";
+import ChatMessages from "@/components/ChatMessages";
+import ChatInput from "@/components/ChatInput";
 import { Message, ChatMessage } from "@/types";
 import { chatService } from "../../services/chatService";
 
@@ -158,7 +158,7 @@ const Chat: React.FC = () => {
   console.log("Passing to ChatMessages:", JSON.stringify(messages, null, 2));
   return (
     <div className="flex flex-col h-screen bg-background">
-      <Header />
+      <ChatHeader />
       <main className="flex-1 overflow-y-auto" id="chat-container">
         <ChatMessages messages={messages} isTyping={isTyping} />
       </main>


### PR DESCRIPTION
## Summary
- fix type for chat messages prop
- import components correctly in Chat page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*